### PR TITLE
Fix mismatch between env value and resulting tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Security   - in case of vulnerabilities
 
 ## [Unreleased]
 
+### Fixed
+- Mismatch between env value and resulting tuple in docs (issue #63, PR #64).
+
 
 ## [3.0.2] - 2021-02-22
 

--- a/docs/source/tuple.rst
+++ b/docs/source/tuple.rst
@@ -10,10 +10,10 @@ Usage
 
 .. code-block:: shell
 
-    export ALLOWED_CATEGORIES=python,vim,git
+    export SAMPLE_GREETING=Hello,world!
 
 .. code-block:: python
 
     >>> import parsenvy
-    >>> parsenvy.tuple('ALLOWED_CATEGORIES')
+    >>> parsenvy.tuple('SAMPLE_GREETING')
     ('Hello', 'world!')


### PR DESCRIPTION
Fixes #63

Fix the mismatch between the values of the environment variable and the parsed tuple in the tuple docs page example.

Also change the environment variable name to match the tuple example on the docs home page.